### PR TITLE
Update the incorrect link

### DIFF
--- a/src/content/blog/olympiads-in-bangladesh.md
+++ b/src/content/blog/olympiads-in-bangladesh.md
@@ -21,7 +21,7 @@ Note that out of these 22 Olympiads 2 of them (Bangla & ICT) don't have any inte
 | Bangladesh Junior Science Olympiad (BDJSO) | 4          | Grade 3-12        | Around July      | [www.bdjso.org](http://www.bdjso.org)                      |
 | Bangladesh Astro Olympiad (BdAO)           | 2          | Grade 8-12        | Around June      | Event Link: <https://fb.me/e/2q8brbO0D>                    |
 | Bangladesh Biology Olympiad (BdB0)         | 4          | Grade 3-12        | Around January   | [www.bdbo.org](http://www.bdbo.org)                        |
-| Bangladesh Physics Olympiad (BdPhO)        | 3          | Grade 6-12        | Around January   | [www.bdpgo.org](www.bdpgo.org)                             |
+| Bangladesh Physics Olympiad (BdPhO)        | 3          | Grade 6-12        | Around January   | [www.bdpho.org](www.bdpho.org)                             |
 | Bangladesh Robot Olympiad (BdRO)           | 2          | Age 7-18          | Segments: 5      | Around July                                                |
 | Bangladesh Math Olympiad (BdMO)            | 4          | Grade 3-12        | Around January   | [www.matholympiad.org.bd](https://www.matholympiad.org.bd) |
 | IQ Olympiad                                | 12         | Grade 1-12        | Around July      | Event Link: <https://fb.me/e/2naEJVwzy>                    |


### PR DESCRIPTION
I updated the incorrect link regarding the Bangladesh Physics Olympiad (BdPhO) , which is NOT www.bdpgo.org but www.bdpho.org. The primary argument for this change is characterized by the existence of the domain 'bdpgo.org.' When we try to access the domain via a web browser like Chromium, we see an error:
<img width="1856" height="1048" alt="Screenshot from 2026-06-29 22-33-08" src="https://github.com/user-attachments/assets/ca51a667-d4d7-4075-876c-a0b550fcdbe7" />
Since we get the error 'DNS_PROBE_FINISHED_NXDOMAIN,' the link is invalid. This is because the domain is non-existent (NXDOMAIN is short for Non-Existent Domain) .  The real website link/domain name of the Bangladesh Physics Olympiad is [www.bdpho.com](www.bdpho.org).