### PR TITLE
Update links for BdRO and BdEO in blog

### DIFF
--- a/src/content/blog/olympiads-in-bangladesh.md
+++ b/src/content/blog/olympiads-in-bangladesh.md
@@ -22,10 +22,10 @@ Note that out of these 22 Olympiads 2 of them (Bangla & ICT) don't have any inte
 | Bangladesh Astro Olympiad (BdAO)           | 2          | Grade 8-12        | Around June      | Event Link: <https://fb.me/e/2q8brbO0D>                    |
 | Bangladesh Biology Olympiad (BdB0)         | 4          | Grade 3-12        | Around January   | [www.bdbo.org](http://www.bdbo.org)                        |
 | Bangladesh Physics Olympiad (BdPhO)        | 3          | Grade 6-12        | Around January   | [www.bdpho.org](www.bdpho.org)                             |
-| Bangladesh Robot Olympiad (BdRO)           | 2          | Age 7-18          | Segments: 5      | Around July                                                |
+| Bangladesh Robot Olympiad (BdRO)           | 2          | Age 7-18          | Segments: 5      | Around July, website: [www.bdro.com](www.bdro.com)         |
 | Bangladesh Math Olympiad (BdMO)            | 4          | Grade 3-12        | Around January   | [www.matholympiad.org.bd](https://www.matholympiad.org.bd) |
 | IQ Olympiad                                | 12         | Grade 1-12        | Around July      | Event Link: <https://fb.me/e/2naEJVwzy>                    |
-| Bangladesh Economics Olympiad (BdEO)       | None       | Grade 8-12        | Around March     |                                                            |
+| Bangladesh Economics Olympiad (BdEO)       | None       | Grade 8-12        | Around March     | https://sites.google.com/view/bdeo/home                    |
 | Blockchain Olympiad (BdBCO)                | 4          | Grade 8-Graduates | Around May       | [www.bcolbd.org](http://www.bcolbd.org)                    |
 | Bangladesh Informatics Olympiad (BdIO)     | None       | Grade 8-12        | Around December  | [olympiad.org.bd](https://www.olympiad.org.bd)             |
 | ICT Olympiad (ICTOBd)                      | TBA        | TBA               | TBA              | TBA                                                        |


### PR DESCRIPTION
In this commit, I added 2 changes to the table. The 2 changes are given below:
1. I added the missing link of the website of the Bangladesh Economics Olympiad (hosted by Google Sites service of the Google company), which is [BDEO](https://sites.google.com/view/bdeo/home). Notice how the link does not work in markdown formatting. This is because Google Sites does not support markdown, as of the time of this commit.
2. I also added the missing link of the Bangladesh Robotics Olympiad website. 